### PR TITLE
Entferne DEV_MODE-Umgebungsvariable aus dem Consumer-Docker-Setup wei…

### DIFF
--- a/Christian_Ibrahim_Jochen/docker-compose.yml
+++ b/Christian_Ibrahim_Jochen/docker-compose.yml
@@ -31,7 +31,6 @@ services:
       - .env
     environment:
       RABBIT_URL: "amqp://rabbitmq"
-      DEV_MODE: "true"
     depends_on:
       - rabbitmq
 


### PR DESCRIPTION
…l schon in der env stehen soll